### PR TITLE
Fix for getting header

### DIFF
--- a/digest-fetch-src.js
+++ b/digest-fetch-src.js
@@ -61,7 +61,7 @@ qop=${this.digest.qop},algorithm="{this.digest.algorithm}",response="${response}
   }
 
   async parseAuth (data) {
-    const h = data.headers['www-authenticate']
+    const h = data.headers.get('www-authenticate')
     this.lastAuth = h
 
     if (!h || h.length < 5) {


### PR DESCRIPTION
Was finding I was unable to connect. Found the auth parsing wasn't being run and found that was because the header was not coming back as it was in a symbol map. Changed accessor to a .get and it now functions for me.