### PR TITLE
fix(addAuth): check if input is a Request object

### DIFF
--- a/digest-fetch-src.js
+++ b/digest-fetch-src.js
@@ -87,7 +87,10 @@ class DigestClient {
     if (typeof(options.factory) == 'function') options = options.factory()
     if (!this.hasAuth) return options
     if (this.logger) this.logger.info(`requesting with auth carried`)
-    const _url = url.replace('//', '')
+
+    const isRequest = typeof(url) === 'object' && typeof(url.url) === 'string'
+    const urlStr = isRequest ? url.url : url
+    const _url = urlStr.replace('//', '')
     const uri = _url.indexOf('/') == -1 ? '/' : _url.slice(_url.indexOf('/'))
     const method = options.method ? options.method.toUpperCase() : 'GET'
 


### PR DESCRIPTION
Since [`node-fetch` accepts url as a plain string or a Request object](https://github.com/node-fetch/node-fetch/blob/38839c53bd417cef440757265f75c8371d4c51e6/src/index.js#L27-L34):
```javascript
/**
 * Fetch function
 *
 * @param   {string | URL | import('./request').default} url - Absolute url or Request instance
 * @param   {*} [options_] - Fetch options
 * @return  {Promise<import('./response').default>}
 */
export default async function fetch(url, options_) {...
```

We need to check it before we treat `url` as a string & use `String.prototype.replace`.

If `url` is a Request object, we will use `Request.url` as the url (in string).

