### PR TITLE
Always treat HTTP 401 as unauthorized

### DIFF
--- a/digest-fetch-src.js
+++ b/digest-fetch-src.js
@@ -40,19 +40,19 @@ class DigestClient {
 
     // Custom authentication failure code for avoiding browser prompt:
     // https://stackoverflow.com/questions/9859627/how-to-prevent-browser-to-invoke-basic-auth-popup-and-handle-401-error-using-jqu
-    this.statusCode = options.statusCode || 401
+    this.statusCode = options.statusCode
     this.basic = options.basic || false
   }
 
   async fetch (url, options={}) {
     if (this.basic) return fetch(url, this.addBasicAuth(options))
     const resp = await fetch(url, this.addAuth(url, options))
-    if (resp.status == this.statusCode) {
+    if (resp.status == 401 || resp.status == this.statusCode) {
       this.hasAuth = false
       await this.parseAuth(resp.headers.get('www-authenticate'))
       if (this.hasAuth) {
         const respFinal = await fetch(url, this.addAuth(url, options))
-        if (respFinal.status == this.statusCode) {
+        if (respFinal.status == 401 || respFinal.status == this.statusCode) {
           this.hasAuth = false
         } else {
           this.digest.nc++


### PR DESCRIPTION
This changes the semantics of the supplied statusCode option to be
treated as an alternative, rather than a replacement, for the standard
HTTP 401.

This helps in generic code where we can't be sure we can persuade the
server to output the alternate error code, but we want to succeed
regardless if we aren't running in a browser.

Amends: https://github.com/devfans/digest-fetch/commit/3600ef55f98b544e36ac7837952eb2c9a45d12e4