### PR TITLE
Add client as an option in the constructor

### DIFF
--- a/digest-fetch-src.js
+++ b/digest-fetch-src.js
@@ -53,12 +53,13 @@ export class DigestClient {
   }
 
   async getClient() {
-    if (typeof (fetch) === 'function') {
-      return fetch;
-    }
     if (this._client == undefined) {
-      const module = await import('node-fetch');
-      this._client = module.default;
+      if (typeof (fetch) === 'function') {
+        this._client = fetch
+      } else {
+        const module = await import('node-fetch');
+        this._client = module.default;
+      }
     }
     return this._client;
   }

--- a/digest-fetch-src.js
+++ b/digest-fetch-src.js
@@ -29,6 +29,7 @@ export class DigestClient {
     this.nonceRaw = 'abcdef0123456789'
     this.logger = options.logger
     this.precomputedHash = options.precomputedHash
+    this._client = options.client
 
     let algorithm = options.algorithm || 'MD5'
     if (!supported_algorithms.includes(algorithm)) {


### PR DESCRIPTION
This adds the `client` option to be allowed to passed in the constructor.

The reason for this is when minifying the code for a Node.js application `node-fetch` is not always available due to renaming of imports by tools such as Rollup.

This still retains the original functionality of not setting the option since `getClient` is unchanged.